### PR TITLE
Fix podspec file

### DIFF
--- a/GuillotineMenu.podspec
+++ b/GuillotineMenu.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "GuillotineMenu"
-  spec.version = “2.0.1”
+  spec.version = "2.0.1"
 
   spec.homepage = "http://yalantis.com/blog/how-we-created-guillotine-menu-animation/"
   spec.summary = "Custom menu transition from Navigation Bar"
@@ -12,7 +12,7 @@ Pod::Spec.new do |spec|
   spec.platform = :ios, '8.0'
   spec.ios.deployment_target = '8.0'
 
-  spec.source = { :git => "https://github.com/Yalantis/GuillotineMenu.git", :tag => “2.0.1” }
+  spec.source = { :git => "https://github.com/Yalantis/GuillotineMenu.git", :tag => "2.0.1" }
 
   spec.requires_arc = true
 


### PR DESCRIPTION
Why:
The double quotes were causing `pod install` to fail

<img width="693" alt="screen shot 2016-03-23 at 1 58 22 pm" src="https://cloud.githubusercontent.com/assets/132980/13995391/5ad03a54-f0ff-11e5-81cc-c34cc016218e.png">
